### PR TITLE
Add second source for neon-wallet db setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 - [Network Protocol](http://docs.neo.org/en-us/node/network-protocol.html) - Explanation of how NEO nodes communicate.
 - [Private Net Docker](https://github.com/CityOfZion/neo-privatenet-docker) - Setup for a private NEO blockchain with an Ubuntu 16.04 docker image.
 - [NEON DB for private nets](https://gist.github.com/birmas/689c37e43c7f55745233d3aeb794f833) - Setup for a NEON database to work with a private net
+- [NEON DB for private nets #2](https://github.com/ixje/neon-wallet-db/blob/ce27d43c5dc25c1f23f07b021ff488ae18c4c229/privnet-install.md) - Setup NEON database inside the private net docker (verbose steps)
 - [Stack Exchange](https://area51.stackexchange.com/proposals/110921/neo-blockchain) - Q&A site for developers, educators, and users of the blockchain. 
 - [Video overviews](https://www.youtube.com/channel/UCzlQUNLrRa8qJkz40G91iJg/videos) - Summary of CoZ project features.
 - [Video tutorial](https://www.youtube.com/watch?v=2RWegc0DWmQ&list=PL_vIhjXh1UTodKsr3uMkFJiMRAZNlJeSX) - YouTube series on smart contract programming.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 - [Network Protocol](http://docs.neo.org/en-us/node/network-protocol.html) - Explanation of how NEO nodes communicate.
 - [Private Net Docker](https://github.com/CityOfZion/neo-privatenet-docker) - Setup for a private NEO blockchain with an Ubuntu 16.04 docker image.
 - [NEON DB for private nets](https://gist.github.com/birmas/689c37e43c7f55745233d3aeb794f833) - Setup for a NEON database to work with a private net
-- [NEON DB for private nets #2](https://github.com/ixje/neon-wallet-db/blob/ce27d43c5dc25c1f23f07b021ff488ae18c4c229/privnet-install.md) - Setup NEON database inside the private net docker (verbose steps)
+- [NEON DB for private nets #2](https://github.com/ixje/neon-wallet-db/blob/master/privnet-install.md) - Setup NEON database inside the private net docker (verbose steps)
 - [Stack Exchange](https://area51.stackexchange.com/proposals/110921/neo-blockchain) - Q&A site for developers, educators, and users of the blockchain. 
 - [Video overviews](https://www.youtube.com/channel/UCzlQUNLrRa8qJkz40G91iJg/videos) - Summary of CoZ project features.
 - [Video tutorial](https://www.youtube.com/watch?v=2RWegc0DWmQ&list=PL_vIhjXh1UTodKsr3uMkFJiMRAZNlJeSX) - YouTube series on smart contract programming.


### PR DESCRIPTION
A slightly more verbose version. These instructions make
`neon-wallet-db` part of the `neo-private-docker` image. It also uses
the existing nodes instead of running another node outside of the image.