### PR TITLE
Add python video tutorials playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 
 ### Python
 - [Python tutorial](https://www.youtube.com/watch?v=OP8z8OLKwC0) - Use Python to Deploy Neo Smart Contracts
+- [Video Tutorials](https://www.youtube.com/playlist?list=PLRzTNBWJe5bzRa2nyTxZyfbI8x93GFd3p) - Dev environment setup, workflows, and smart contracts written in Python
 
 ## Wallets
 


### PR DESCRIPTION
Added a link in the Smart Contracts: Python section to a video playlist of tutorials. I was originally going to submit new PRs with the links for each video I create, but think this is possibly a better solution. But if you think it might be better to add links to the individual videos as they are released, I can close this PR, and do that instead.