### PR TITLE
Deprecation marker and link removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 - [neoscan.io](https://neoscan.io/) - Explorer created by CoZ.
 - [CoZ TestNet neoscan.io](https://coz.neoscan-testnet.io/) - Neoscan for CoZ TestNet
 - [neotracker.io](https://neotracker.io/) - MainNet and TestNet explorer, created by the Neo Tracker team.
-- [explorer.neoverse.io](http://explorer.neoverse.io/) - Explorer created by the NEOverse team.
+- [~~explorer.neoverse.io~~](http://explorer.neoverse.io/) (Deprecated) - Explorer created by the NEOverse team.
 
 ## City of Zion
 
@@ -75,7 +75,7 @@
 - [Facebook](https://www.facebook.com/CityOfZionOfficial/) - Facebook account of CoZ.
 - [Github](https://github.com/CityOfZion) - Code repositories owned by CoZ.
 - [Medium](https://medium.com/@cityofzion) - Weekly reports from CoZ.
-- [Trello](https://trello.com/b/6TngvuLf/neoblockchaindevelopment) - Process tracker for blockchain development and design, as well as feature requests.
+- [~~Trello~~](https://trello.com/b/6TngvuLf/neoblockchaindevelopment) (Deprecated) - Process tracker for blockchain development and design, as well as feature requests.
 - [Twitter](https://twitter.com/coz_official) - Twitter account of CoZ.
 - [Website](http://cityofzion.io) - Homepage for CoZ.
 
@@ -86,8 +86,6 @@
 - [dAppTemplate_MEAN](https://github.com/CityOfZion/dAppTemplate_MEAN) - Interface for communicating with NEO nodes, to help with development of a dApp.
 - [Java smart contracts](https://github.com/neo-project/examples-java) - Examples of smart contracts written in Java from NEO core team.
 - [Kotlin smart contracts](https://github.com/neo-project/examples-kotlin) - Examples of smart contracts written in Kotlin from NEO core team.
-- [Python smart contracts](https://github.com/CityOfZion/awesome-neo/resources/python-examples.md#code-examples) - Examples of smart contracts written in Python, from the Neo Python core team and DApp competition entrants.
-
 
 ## dApps
 
@@ -139,7 +137,6 @@
 - [CoinSpot](https://www.coinspot.com.au/buy/ans) - An Australian exchange that allows trading for Australian Dollars (AUD).
 - [CoinSwitch](https://www.coinswitch.co/exchange/btc/neo) - An Indian exchange that allows trading for various other cryptocurrencies.
 - [CoolCoin](https://www.coolcoin.com/btc/neo/) - An Australian exchange that allows trading for BTC. *English and Chinese interfaces*
-- [CryptoMate](https://cryptomate.co.uk/buy-neo/) - A British exchange that allows purchases using GBP.
 - [Cryptopia.co](https://www.cryptopia.co.nz/Exchange?market=NEO_BTC) - A New Zealand-based exchange that allows trading for BTC, LTC and DOGE.
 - [Exrates](https://exrates.me/dashboard?name=BTC/NEO) - An Armenian exchange that allows trading for BTC and USDT. *English, Russian, Chinese, Indonesian and Arabic interfaces*
 - [Gate.io](https://gate.io/trade/neo_usdt) - A United States-based exchange. Allows trading for USDT and BTC. *English and Chinese interfaces*

--- a/resources/coz_application_form.md
+++ b/resources/coz_application_form.md
@@ -2,9 +2,9 @@
 
 The **City of Zion** (**CoZ**) is a group of open source developers formed for the purpose of furthering the progress of the NEO blockchain. We are always looking for talented people to join our ranks. 
 
-If you want to help with one of our projects, you can do it directly through GitHub. Our repository is located at https://github.com/CityOfZion. You can also join us on project specific Slack channels, access to which will be granted through an application process. Please see the form below.
+If you want to help with one of our projects, you can do it directly through GitHub. Our repository is located at https://github.com/CityOfZion. You can also join us on project specific Discord channels, access to which will be granted through an application process. Please see the form below.
 
-In the form, please provide your preferred name (real or not), GitHub username, Slack screen name, skills, public wallet address, and what you want to specifically work on.
+In the form, please provide your preferred name (real or not), GitHub username, Discord screen name, skills, public wallet address, and what you want to specifically work on.
 
 -------------------------------------------------------------------------------------------------------------------------------
 
@@ -12,7 +12,7 @@ In the form, please provide your preferred name (real or not), GitHub username, 
 
 **GitHub Username**: CoZ uses GitHub in order to collaborate and keep track of work. All developers are required to have an account. Previous work done on a GitHub account contributes to our decision-making process.
 
-**Slack Screen Name**: CoZ uses Slack in order to collaborate with each other and report results. All developers are required to have an account.
+**Discord Screen Name**: CoZ uses Discord in order to collaborate with each other and report results. All developers are required to have an account.
 
 **Public Wallet Address**: CoZ occasionally will receive funding from the community. Your public wallet address is how we send compensation for work done in these instances.
 
@@ -32,4 +32,4 @@ You must be logged into a Google account in order to fill out the form; this is 
 
 If you are an experienced developer, please also consider taking the time to commit to our NEO Stack Exchange proposal at: http://area51.stackexchange.com/proposals/110921/neo-blockchain
 
-**NOTE**: If for some reason the link stops working, hop on the NEO Blockchain Slack or message us here at GitHub, and we'll get it back up again. Thanks!
+**NOTE**: If for some reason the link stops working, hop on the NEO Blockchain Discord or message us here at GitHub, and we'll get it back up again. Thanks!

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -20,7 +20,7 @@
 
 5. *How can I check the status of my transaction?*
 
-   You can check it on any NEO blockchain explorer, such as http://antcha.in or http://antchain.xyz. You can find additional blockchain explorers in the sidebar of the [NEO subreddit](https://www.reddit.com/r/NEO/).
+   You can check it on any NEO blockchain explorer, such as http://antcha.in or ~~http://antchain.xyz~~ (Deprecated). You can find additional blockchain explorers in the sidebar of the [NEO subreddit](https://www.reddit.com/r/NEO/).
 
 6. *How do I know whether my wallet is fully synchronised with the blockchain?*
 
@@ -40,7 +40,7 @@
 
 9. *I can't see my NEO in my wallet! Is it gone?*
 
-   1. Most of the time, whenever your NEO or GAS is not showing up in your wallet, the problem lies with the wallet. To make sure your NEO is safe, you can check your balance on a NEO blockchain explorer, such as http://antcha.in or https://antchain.xyz/. 
+   1. Most of the time, whenever your NEO or GAS is not showing up in your wallet, the problem lies with the wallet. To make sure your NEO is safe, you can check your balance on a NEO blockchain explorer, such as http://antcha.in or ~~https://antchain.xyz/~~ (Deprecated). 
 
    2. Make sure your wallet is fully synchronised. If it is, and there is still no NEO in your wallet, then:
 
@@ -50,8 +50,8 @@
 
 10. *How can a Mac user claim GAS?*
 
-    Mac users can use [this link](https://github.com/CityOfZion/neon-wallet/releases/download/0.0.5/Mac.Neon-0.0.5.dmg) to download the NEON wallet, which they can use to claim Gas (and send NEO/GAS). 
-    
+    Mac users can use [this link](https://github.com/CityOfZion/neon-wallet/releases) to download the NEON wallet, which they can use to claim Gas (and send NEO/GAS).
+
 11. *If I keep my NEO on an exchange, can I still get my GAS?*
 
     This depends on the exchange; some (like [Binance](https://www.binance.com/)) have chosen to give users their GAS when you leave your NEO on the exchange, while others (like [Bittrex](https://www.bittrex.com/)) keep the NEO for themselves. If you want to make sure you receive your Gas, move your NEO to a private wallet and manually claim your GAS.
@@ -105,7 +105,7 @@
 
 21. *Is there an equivalent of ERC-20 standard for NEO?*
 
-    Yes, it's called [NEP-5](https://github.com/neo-project/proposals) (NEP is short for *NEO Enhancement Proposals*).
+    Yes, it's called [NEP-5](https://github.com/neo-project/proposals/blob/master/nep-5.mediawiki) (NEP is short for *NEO Enhancement Proposals*).
 
 ---
-If you did not find your answer in the FAQ listed above, you can always ask your question in the [NEO Slack Channel](http://slack.cityofzion.io/).
+If you did not find your answer in the FAQ listed above, you can always ask your question in the [NEO Discord Channel](https://discordapp.com/invite/R8v48YA).

--- a/resources/neo-merchandise.md
+++ b/resources/neo-merchandise.md
@@ -37,21 +37,15 @@ When listing a product, stick to the following guidelines:
 - [Blocktees](https://www.blocktees.store/collections/neo-smart-collection) - T-shirts and caps.
 - [Crypto Fashion](https://www.amazon.com/s/ref=w_bl_sl_s_ap_web_7141123011?ie=UTF8&node=7141123011&field-brandtextbin=Crypto+Fashion) - Cryptocurrency related T-Shirts, available on Amazon.
 - [Distressed Logo](https://www.amazon.com/dp/B076YYD3V9) - T-shirt with distorted logo and name, available on Amazon in multiple colours. Created by *Hindsight_DJ*.
-- [HODL Apparels](https://www.redbubble.com/people/hecadothbelial?ref=artist_title_name) - Coin and token related t-shirts. Created by *Oksano*.
 - [NEO Logo shirt](https://www.amazon.com/dp/B074Y6W1S1?th=1) - T-shirt with logo. Created by *Azza1070*.
 - [NEO Nation](https://www.amazon.com/s/ref=w_bl_sl_s_ap_web_7141123011?ie=UTF8&node=7141123011&field-brandtextbin=NEO%20Nation) - Amazon based seller of various t-shirts.
 - [Taobao Focus](https://shop.tbfocus.com/item.php?id=555009655617#3586596243203) - Black and white t-shirts.
 - [Wake Up Neo](https://www.amazon.com/dp/B076YVLVLY?th=1) - T-shirt with logo and the text 'Wake Up NEO', available on Amazon in multiple colours. Created by *Hindsight_DJ*.
 
-
 ## Other
 
 - [Neo Planet](https://fineartamerica.com/featured/neo-planet-pnp.html) - A piece of digital artwork by *Pnp*, available on different media such as posters, prints, mugs and phone covers.
 
-
 ## Stickers
 
-- [NEO Sticker](https://www.redbubble.com/people/tshirtdesign/works/27735886-neo-former-antshares-logo?p=sticker) - A simple logo sticker, available in multiple sizes. Created by *rahb_*.
-- [NEO Sticker](https://www.redbubble.com/people/rahbwormlord/works/27799013-neo-smart-economy-hd-logo?p=sticker) - Higher resolution logo sticker. Available in two sizes. Created by *rahb_*.
 - [NEO Sticker](http://imgur.com/iqvFNAw) - A sticker with 'NEO smart economy' on it. Order it at [blockrebelsmarketing@gmail.com](mailto:blockrebelsmarketing@gmail.com).
-- [NEO Sticker](https://www.redbubble.com/people/with-care/works/27126848-neo?grid_pos=2&p=sticker&rbs=3fd9cbb7-0d6a-4a49-9ae5-a4943ccfcf7d&ref=shop_grid) - A simple logo sticker. Created by *Crypto Keeper*.


### PR DESCRIPTION
Following links are remained on the documents and marked as deprecated:

* http://explorer.neoverse.io/
* https://trello.com/b/6TngvuLf/neoblockchaindevelopment
* https://antchain.xyz/

Following links are removed completed

* [Python smart contracts](https://github.com/CityOfZion/awesome-neo/resources/python-examples.md#code-examples)

Following Exchange is considered irrelevant to NEO/GAS trading and hence removed:

* [CryptoMate](https://cryptomate.co.uk/buy-neo/)

Following merchandise page is considered as obsolete and hence removed:

- [HODL Apparels](https://www.redbubble.com/people/hecadothbelial?ref=artist_title_name)
- [NEO Sticker](https://www.redbubble.com/people/tshirtdesign/works/27735886-neo-former-antshares-logo?p=sticker)
- [NEO Sticker](https://www.redbubble.com/people/rahbwormlord/works/27799013-neo-smart-economy-hd-logo?p=sticker)
- [NEO Sticker](https://www.redbubble.com/people/with-care/works/27126848-neo?grid_pos=2&p=sticker&rbs=3fd9cbb7-0d6a-4a49-9ae5-a4943ccfcf7d&ref=shop_grid)


`neon-wallet` release link is now replaced with its release page.

There are few 'Slack' word and URL references, that are now replaced with correct 'Discord' 
reference.

