### PR TITLE
Update to a later chain.acc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 ### MainNet
 
-- [MainNet (S3 - Chain09Mar.zip)](https://s3.eu-west-2.amazonaws.com/ashant-neo/Chain09Mar.zip) - Up to block 2002315.
+- [Mainnet (S3 - chain.acc.zip)](https://s3.eu-west-2.amazonaws.com/ashant-neo/chain.acc.zip) - Up to block ~2022949
 
 ### TestNet
 


### PR DESCRIPTION
Since 2.7.3 there are updates to chain.acc importing speed, making it the more practical approach to take. The `.acc` file is also a smaller size and platform agnostic.