### PR TITLE
Removed old chain.acc bootstrap files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,8 @@
 
 Please refer to [this tutorial](https://medium.com/@gubanotorious/test-networks-and-fund-requests-for-smart-contract-and-dapp-testing-on-the-neo-blockchain-583a1795412) on how to use bootstrap files:
 
-### MainNet neo-cli 2.7.6
+### MainNet neo-cli 2.7.6+
 
-- [MainNet (Google Drive - chain.acc)](https://drive.google.com/open?id=1tB6HjS89tsNPH890jB6NnOfgiaO8ckI_) - 5/25/2018
-- [MainNet (MEGA - chain.acc)](https://mega.nz/#!wBtjhTxb!4JmHrmvBsAR5HtSujVQb-ZikJqiR6-hOnu84vOthu_M) - 5/25/2018
-- [MainNet (Google Drive - Chain folder)](https://drive.google.com/file/d/1g4Vmi-A8fAx425PtvL6w8gGA5wzGMTlW) - 6/22/2018
-- [MainNet (nofile.io - Chain folder)](https://nofile.io/f/4x1J3pzytug/chainfolder.zip) - 6/22/2018
 - [MainNet (azure NGD > Deadblock Fix)](https://neo-cdn.azureedge.net/client/chain.zip) - 8/16/2018 (MD5: 06ea9760c317b3693c758bbc07b0ad96)
 
 ### MainNet NEO-GUI 2.7.6


### PR DESCRIPTION
There doesn't seem to be any reason to keep the old, not working, bootstrap files in the list anymore. Anything I'm missing?