### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Please refer to [this tutorial](https://medium.com/@gubanotorious/test-networks-
 
 ## SDKs
 
-- [neo-go](https://github.com/CityOfZion/neo-go) - Golang Node and SDK for the NEO blockchain.
+- [neo-go](https://github.com/nspcc-dev/neo-go) - Golang Node and SDK for the NEO blockchain.
 - [neo-go-sdk](https://github.com/CityOfZion/neo-go-sdk) - Golang SDK for the NEO blockchain.
 - [neo-utils](https://github.com/O3Labs/neo-utils) - Golang SDK for the NEO blockchain developed by O3.
 - [neo-js](https://github.com/CityOfZion/neo-js) - Javascript Node and SDK for the NEO blockchain.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Please refer to [this tutorial](https://medium.com/@gubanotorious/test-networks-
 
 ## Blockchain Explorers
 
-- [antcha.in](http://antcha.in/) - Mature explorer from before the re-brand.
 - [scan.nel.group](https://scan.nel.group/#mainnet) - NEL NEO Mainnet Explorer.
 - [neoscan.io](https://neoscan.io/) - NEO Mainnet Explorer created by CoZ.
 - [neotracker.io](https://neotracker.io/) - MainNet and TestNet explorer, created by the Neo Tracker team.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <img
-    src="http://res.cloudinary.com/vidsy/image/upload/v1503160820/CoZ_Icon_DARKBLUE_200x178px_oq0gxm.png"
+    src="https://raw.githubusercontent.com/CityOfZion/visual-identity/develop/_CoZ%20Branding/_Logo/_Logo%20icon/_PNG%20200x178px/CoZ_Icon_DARKBLUE_200x178px.png"
     width="125px"
   >
 </p>

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ Please refer to [this tutorial](https://medium.com/@gubanotorious/test-networks-
 ## GAS Calculators
 
 - [neodepot.org](https://neodepot.org/) - Calculator with an array of NEO statistical charts.
-- [neogas.io](https://neogas.io/) - Created by [@drpepper](https://www.reddit.com/user/drpepper).
 - [neotogas.com](https://neotogas.com) - Created by [@n1njawtf](https://twitter.com/n1njawtf).
 
 


### PR DESCRIPTION
- Fix logo link
- Update neo-go link (now it's under the neo-spcc umbrella)
- Remove neogas as the website seems to be abandoned (it's just a standard placeholder parking webpage with a broken certificate)
- Remove antcha.in because it's down. I'm not sure about removing this one because it works reliably and will probably get back up at some point, but, given that it has not received any update in a long time and there are plenty of other, actively-maintained block explorers, I'll remove it. If someone thinks that this should not be done just say it and I'll re-add it.