### PR TITLE
Remove most wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,6 @@ Please refer to [this tutorial](https://medium.com/@gubanotorious/test-networks-
 - [neon-wallet](https://github.com/CityOfZion/neon-wallet) - A light wallet for the blockchain.
 - [O<sub>3</sub>](https://o3.network/) - macOS, Windows, Linux, iOS and Android wallet
 - [ansy](https://snowypowers.github.io/ansy/) - A minimal paper wallet generator.
-- [SEA Wallet](https://otcgo.cn/#/) - A Chinese asset management platform. *Chinese interface*
-- [Ledger Wallet](https://www.ledger.com/neo-wallet/) - The app for the Ledger wallet. Created by coranos2.
-- [neo-cli](https://github.com/neo-project/neo-cli/) - An official wallet built by the core team, which is command-line based.
-- [neo-gui](https://github.com/neo-project/neo-gui/) - An official wallet built by the core team, which has a UI.
-- [neotracker.io](https://neotracker.io/wallet) - A web based wallet.
-- [Aphelion Wallet](https://aphelion.org/#wallet) - Desktop, iOS, Android and web wallet
-- [NEO App](https://play.google.com/store/apps/details?id=neo.app) - Android wallet developed by NEO dev Peter Lin
-- [iWallic](https://iwallic.com/en/index.html) - Web and Android wallet
 ---
 
 <p align="center">


### PR DESCRIPTION
Most of the wallets listed here are either:
- Not maintained anymore
- Buggy (see all the complaints about neotracker bugs on the Telegram chat)
- Not really useful (the ledger nano page is just a marketing SEO page)
- Do not conform to community recommendations (the community just recommends O3 & neon)

Given that this is meant to be a curated list of resources, I don't see the point in having a big list of wallets which is different from the usual community-recommended wallets, this is why I've removed most of them in order to only leave the "awesome" ones, where awesome is defined as those that are most used & recommended on telegram and reddit.